### PR TITLE
Fix TypeError on `postToChat` in Python 3

### DIFF
--- a/mcpi/connection.py
+++ b/mcpi/connection.py
@@ -1,7 +1,7 @@
 import socket
 import select
 import sys
-from .util import flatten_parameters_to_string
+from .util import flatten_parameters_to_bytestring
 
 """ @author: Aron Nieminen, Mojang AB"""
 
@@ -29,8 +29,14 @@ class Connection:
             sys.stderr.write(e)
 
     def send(self, f, *data):
-        """Sends data. Note that a trailing newline '\n' is added here"""
-        s = "%s(%s)\n"%(f, flatten_parameters_to_string(data))
+        """
+        Sends data. Note that a trailing newline '\n' is added here
+
+        The protocol uses CP437 encoding - https://en.wikipedia.org/wiki/Code_page_437
+        which is mildly distressing as it can't encode all of Unicode.
+        """
+
+        s = b"".join([f, b"(", flatten_parameters_to_bytestring(data), b")", b"\n"])
 
         self._send(s)
 

--- a/mcpi/minecraft.py
+++ b/mcpi/minecraft.py
@@ -29,37 +29,37 @@ class CmdPositioner:
 
     def getPos(self, id):
         """Get entity position (entityId:int) => Vec3"""
-        s = self.conn.sendReceive(self.pkg + ".getPos", id)
+        s = self.conn.sendReceive(self.pkg + b".getPos", id)
         return Vec3(*list(map(float, s.split(","))))
 
     def setPos(self, id, *args):
         """Set entity position (entityId:int, x,y,z)"""
-        self.conn.send(self.pkg + ".setPos", id, args)
+        self.conn.send(self.pkg + b".setPos", id, args)
 
     def getTilePos(self, id):
         """Get entity tile position (entityId:int) => Vec3"""
-        s = self.conn.sendReceive(self.pkg + ".getTile", id)
+        s = self.conn.sendReceive(self.pkg + b".getTile", id)
         return Vec3(*list(map(int, s.split(","))))
 
     def setTilePos(self, id, *args):
         """Set entity tile position (entityId:int) => Vec3"""
-        self.conn.send(self.pkg + ".setTile", id, intFloor(*args))
+        self.conn.send(self.pkg + b".setTile", id, intFloor(*args))
 
     def setting(self, setting, status):
         """Set a player setting (setting, status). keys: autojump"""
-        self.conn.send(self.pkg + ".setting", setting, 1 if bool(status) else 0)
+        self.conn.send(self.pkg + b".setting", setting, 1 if bool(status) else 0)
 
 
 class CmdEntity(CmdPositioner):
     """Methods for entities"""
     def __init__(self, connection):
-        CmdPositioner.__init__(self, connection, "entity")
+        CmdPositioner.__init__(self, connection, b"entity")
 
 
 class CmdPlayer(CmdPositioner):
     """Methods for the host (Raspberry Pi) player"""
     def __init__(self, connection):
-        CmdPositioner.__init__(self, connection, "player")
+        CmdPositioner.__init__(self, connection, b"player")
         self.conn = connection
 
     def getPos(self):
@@ -77,19 +77,19 @@ class CmdCamera:
 
     def setNormal(self, *args):
         """Set camera mode to normal Minecraft view ([entityId])"""
-        self.conn.send("camera.mode.setNormal", args)
+        self.conn.send(b"camera.mode.setNormal", args)
 
     def setFixed(self):
         """Set camera mode to fixed view"""
-        self.conn.send("camera.mode.setFixed")
+        self.conn.send(b"camera.mode.setFixed")
 
     def setFollow(self, *args):
         """Set camera mode to follow an entity ([entityId])"""
-        self.conn.send("camera.mode.setFollow", args)
+        self.conn.send(b"camera.mode.setFollow", args)
 
     def setPos(self, *args):
         """Set camera entity position (x,y,z)"""
-        self.conn.send("camera.setPos", args)
+        self.conn.send(b"camera.setPos", args)
 
 
 class CmdEvents:
@@ -99,11 +99,11 @@ class CmdEvents:
 
     def clearAll(self):
         """Clear all old events"""
-        self.conn.send("events.clear")
+        self.conn.send(b"events.clear")
 
     def pollBlockHits(self):
         """Only triggered by sword => [BlockEvent]"""
-        s = self.conn.sendReceive("events.block.hits")
+        s = self.conn.sendReceive(b"events.block.hits")
         events = [e for e in s.split("|") if e]
         return [BlockEvent.Hit(*list(map(int, e.split(",")))) for e in events]
 
@@ -120,51 +120,51 @@ class Minecraft:
 
     def getBlock(self, *args):
         """Get block (x,y,z) => id:int"""
-        return int(self.conn.sendReceive("world.getBlock", intFloor(args)))
+        return int(self.conn.sendReceive(b"world.getBlock", intFloor(args)))
 
     def getBlockWithData(self, *args):
         """Get block with data (x,y,z) => Block"""
-        ans = self.conn.sendReceive("world.getBlockWithData", intFloor(args))
+        ans = self.conn.sendReceive(b"world.getBlockWithData", intFloor(args))
         return Block(*list(map(int, ans.split(","))))
     """
         @TODO
     """
     def getBlocks(self, *args):
         """Get a cuboid of blocks (x0,y0,z0,x1,y1,z1) => [id:int]"""
-        return int(self.conn.sendReceive("world.getBlocks", intFloor(args)))
+        return int(self.conn.sendReceive(b"world.getBlocks", intFloor(args)))
 
     def setBlock(self, *args):
         """Set block (x,y,z,id,[data])"""
-        self.conn.send("world.setBlock", intFloor(args))
+        self.conn.send(b"world.setBlock", intFloor(args))
 
     def setBlocks(self, *args):
         """Set a cuboid of blocks (x0,y0,z0,x1,y1,z1,id,[data])"""
-        self.conn.send("world.setBlocks", intFloor(args))
+        self.conn.send(b"world.setBlocks", intFloor(args))
 
     def getHeight(self, *args):
         """Get the height of the world (x,z) => int"""
-        return int(self.conn.sendReceive("world.getHeight", intFloor(args)))
+        return int(self.conn.sendReceive(b"world.getHeight", intFloor(args)))
 
     def getPlayerEntityIds(self):
         """Get the entity ids of the connected players => [id:int]"""
-        ids = self.conn.sendReceive("world.getPlayerIds")
+        ids = self.conn.sendReceive(b"world.getPlayerIds")
         return list(map(int, ids.split("|")))
 
     def saveCheckpoint(self):
         """Save a checkpoint that can be used for restoring the world"""
-        self.conn.send("world.checkpoint.save")
+        self.conn.send(b"world.checkpoint.save")
 
     def restoreCheckpoint(self):
         """Restore the world state to the checkpoint"""
-        self.conn.send("world.checkpoint.restore")
+        self.conn.send(b"world.checkpoint.restore")
 
     def postToChat(self, msg):
         """Post a message to the game chat"""
-        self.conn.send("chat.post", msg)
+        self.conn.send(b"chat.post", msg)
 
     def setting(self, setting, status):
         """Set a world setting (setting, status). keys: world_immutable, nametags_visible"""
-        self.conn.send("world.setting", setting, 1 if bool(status) else 0)
+        self.conn.send(b"world.setting", setting, 1 if bool(status) else 0)
 
     @staticmethod
     def create(address = "localhost", port = 4711):

--- a/mcpi/util.py
+++ b/mcpi/util.py
@@ -6,5 +6,13 @@ def flatten(l):
             for ee in flatten(e): yield ee
         else: yield e
 
-def flatten_parameters_to_string(l):
-    return ",".join(map(str, flatten(l)))
+def flatten_parameters_to_bytestring(l):
+    return b",".join(map(_misc_to_bytes, flatten(l)))
+
+def _misc_to_bytes(m):
+    """
+    Convert an arbitrary object into a string encoded as a CP437 series of bytes.
+
+    See `Connection.send` for more details.
+    """
+    return str(m).encode("cp437")

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -28,7 +28,7 @@ def mc(monkeypatch):
         `sendall` takes _`bytes`_ explicitly in Python 3, _not_ `str`
         """
 
-        assert isinstance(b, six.binary_type), "socket.socker.sendall was given non-bytes (%s)" % str(type(b))
+        assert isinstance(b, six.binary_type), "socket.socket.sendall was given non-bytes (%s)" % str(type(b))
 
     monkeypatch.setattr("socket.socket.connect", lambda x, y: None)
     monkeypatch.setattr("socket.socket.sendall", dummy_sendall)

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -31,7 +31,7 @@ def mc(monkeypatch):
         assert isinstance(b, six.binary_type), "socket.socker.sendall was given non-bytes (%s)" % str(type(b))
 
     monkeypatch.setattr("socket.socket.connect", lambda x, y: None)
-    monkeypatch.setattr("socket.socket.sendall", lambda x, y: dummy_sendall)
+    monkeypatch.setattr("socket.socket.sendall", dummy_sendall)
 
     def dummy_send(self, command):
         """

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -41,7 +41,7 @@ def mc(monkeypatch):
 def test_hello_world(mc):
     mc.postToChat("Hello world")
 
-    assert mc.conn.lastSent == "chat.post(Hello world)\n"
+    assert mc.conn.lastSent == b"chat.post(Hello world)\n"
 
 
 def test_get_pos(mc):
@@ -57,7 +57,7 @@ def test_set_block(mc):
     x, y, z = mc.player.getPos()
     mc.setBlock(x + 1, y, z, 1)
 
-    assert mc.conn.lastSent == "world.setBlock(%d,%d,%d,%d)\n" % (x + 1, y, z, 1)
+    assert mc.conn.lastSent == ("world.setBlock(%d,%d,%d,%d)\n" % (x + 1, y, z, 1)).encode("cp437")
 
 
 def test_blocks_as_variables(mc):

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -11,6 +11,7 @@ least verifies that the commands still exist, which is the most likely cause of 
 """
 
 import pytest
+import six
 
 from mcpi import minecraft
 from mcpi import block
@@ -20,8 +21,17 @@ from time import sleep
 
 @pytest.fixture(autouse=True)
 def mc(monkeypatch):
+    def dummy_sendall(self, b):
+        """
+        https://docs.python.org/3/library/socket.html#socket.socket.sendall
+
+        `sendall` takes _`bytes`_ explicitly in Python 3, _not_ `str`
+        """
+
+        assert isinstance(b, six.binary_type), "socket.socker.sendall was given non-bytes (%s)" % str(type(b))
+
     monkeypatch.setattr("socket.socket.connect", lambda x, y: None)
-    monkeypatch.setattr("socket.socket.sendall", lambda x, y: None)
+    monkeypatch.setattr("socket.socket.sendall", lambda x, y: dummy_sendall)
 
     def dummy_send(self, command):
         """


### PR DESCRIPTION
`TypeError: 'str' does not support the buffer interface`

https://docs.python.org/3/library/socket.html#socket.socket.sendall -
sendall takes bytes, and "foo" isn't bytes in Py3!

(This is a terrible bug report because I don't have internet access from the machine I demonstrated it on...)